### PR TITLE
updated to support k8s >= 1.25

### DIFF
--- a/letsencrypt-issuers/Chart.yaml
+++ b/letsencrypt-issuers/Chart.yaml
@@ -1,5 +1,5 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "2.1"
 description: A Helm to deploy LetsEncrypt ClusterIssuers for production and staging
 name: letsencrypt-issuers
-version: 2.1.0
+version: 3.0.0

--- a/letsencrypt-issuers/templates/clusterIssuers.yaml
+++ b/letsencrypt-issuers/templates/clusterIssuers.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: {{ .Values.staging.name }}
@@ -16,7 +16,7 @@ spec:
         ingress:
           class: nginx
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: {{ .Values.prod.name }}

--- a/tls-ingress/Chart.yaml
+++ b/tls-ingress/Chart.yaml
@@ -1,5 +1,5 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "3.0"
 description: This chart deploys an ingress that requests https certificates and routes traffic
 name: tls-ingress
-version: 3.1.1
+version: 4.0.0

--- a/tls-ingress/templates/ingress.yaml
+++ b/tls-ingress/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- range .Values.ingresses }}
 {{- $ingress := . }}
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .name | default (lower (randAlphaNum 20)) | quote }}
@@ -9,7 +9,6 @@ metadata:
     chart: {{ template "tls-ingress.chart" $ }}
     release: {{ $.Release.Name }}
   annotations:
-    kubernetes.io/ingress.class: nginx
     {{- if $.Values.tls.clusterIssuer }}
     cert-manager.io/cluster-issuer: {{ $.Values.tls.clusterIssuer }}
     {{- end }}
@@ -29,6 +28,7 @@ metadata:
 {{ toYaml $ingress.annotations | indent 4 }}
     {{- end }}
 spec:
+  ingressClassName: nginx
 {{- if $.Values.tls }}
   tls:
     - hosts:
@@ -45,8 +45,11 @@ spec:
         {{- range $ingress.paths }}
           - path: {{ .path }}
             backend:
-              serviceName: {{ .serviceName }}
-              servicePort: {{ .port }}
+              service:
+                name: {{ .serviceName }}
+                port:
+                  number: {{ .port }}
+            pathType: ImplementationSpecific 
         {{- end }}
     {{- end }}
 {{- end}}

--- a/tls-ingress/values.yaml
+++ b/tls-ingress/values.yaml
@@ -1,14 +1,12 @@
-
 ingresses:
   - paths:
-    - path: /
-      serviceName: hello-service
-      port: 80
+      - path: /
+        serviceName: hello-service
+        port: 80
     rewrite: /
     readTimeout: 60
     annotations: {}
     configurationSnippets: []
-
 
 configurationSnippets: []
 


### PR DESCRIPTION
Mise à jour des charts helm pour remplacer les apis _deprecated_ ou _removed_ dans k8s 1.22 et 1.25 