### PR TITLE
Ajout config ingressClassName

### DIFF
--- a/tls-ingress/Chart.yaml
+++ b/tls-ingress/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "3.0"
 description: This chart deploys an ingress that requests https certificates and routes traffic
 name: tls-ingress
-version: 4.0.0
+version: 4.1.0

--- a/tls-ingress/templates/ingress.yaml
+++ b/tls-ingress/templates/ingress.yaml
@@ -28,7 +28,7 @@ metadata:
 {{ toYaml $ingress.annotations | indent 4 }}
     {{- end }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ .ingressClassName | default $.Values.defaultIngressClassName }}
 {{- if $.Values.tls }}
   tls:
     - hosts:

--- a/tls-ingress/values.yaml
+++ b/tls-ingress/values.yaml
@@ -7,6 +7,7 @@ ingresses:
     readTimeout: 60
     annotations: {}
     configurationSnippets: []
+    #ingressClassName: nginx-internal
 
 configurationSnippets: []
 
@@ -17,5 +18,6 @@ tls:
   clusterIssuer: letsencrypt-prod
   secretName: chart-example-local-tls
 
+defaultIngressClassName: nginx
 defaultReadTimeout: 30
 defaultSendTimeout: 30


### PR DESCRIPTION
ajout de l'option pour préciser le ingressClassName, était autrefois remplacé via les annotations