### PR TITLE
updated clamav image tag

### DIFF
--- a/clamav/Chart.yaml
+++ b/clamav/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: "1.9"
+appVersion: "1.9.50"
 description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats.
 name: clamav
 type: application
-version: 1.0.3
+version: 1.0.4
 home: https://www.clamav.net
 icon: https://www.clamav.net/assets/clamav-trademark.png
 sources:

--- a/clamav/values.yaml
+++ b/clamav/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: mailu/clamav
-  tag: "1.9"
+  tag: "1.9.50"
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
This is a critical release. Recently two new CVE's have been discovered for clamav. The below two CVE for Clamav are addressed in this release:
[CVE-2023-20032](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-20032):
Fixed a possible remote code execution vulnerability in the HFS+ file parser.
Issue affects versions 1.0.0 and earlier, 0.105.1 and earlier, and 0.103.7 and
earlier.

[CVE-2023-20052](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-20052):
Fixed a possible remote information leak vulnerability in the DMG file parser.
Issue affects versions 1.0.0 and earlier, 0.105.1 and earlier, and 0.103.7 and
earlier.

The clamav image has been updated to alpine 3.17.2 which contains the new version of clamav that addresses these two CVE's.